### PR TITLE
feat: local onError handler didn't override global

### DIFF
--- a/src/data-provider/resource-provider/ResourceProvider.tsx
+++ b/src/data-provider/resource-provider/ResourceProvider.tsx
@@ -17,12 +17,14 @@ interface ResourceConfigProviderProps {
 const defaultFunctions = getDefaultResourceConfig(axios)
 
 export const ResourceProvider = ({ options = {}, children }: ResourceConfigProviderProps): React.ReactElement => {
-  const { clientConfig, ...apiFunctions } = options
-
-  const api = useMemo(() => deepmerge(defaultFunctions, apiFunctions) as ResourceDefaultConfig, [apiFunctions])
+  const api = useMemo(() => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { clientConfig, ...apiFunctions } = options
+    return deepmerge(defaultFunctions, apiFunctions) as ResourceDefaultConfig
+  }, [options])
   return (
     <ResourceConfigContext.Provider value={api}>
-      <ResourceProviderClient config={clientConfig}>{children}</ResourceProviderClient>
+      <ResourceProviderClient config={options.clientConfig}>{children}</ResourceProviderClient>
     </ResourceConfigContext.Provider>
   )
 }

--- a/src/data-provider/resource-provider/hooks/fetch-resource/interfaces.ts
+++ b/src/data-provider/resource-provider/hooks/fetch-resource/interfaces.ts
@@ -1,7 +1,10 @@
 import { FetchQueryOptions, UseQueryOptions, UseQueryResult } from 'react-query'
 import { RequestConfig } from '../../request-types'
+import { SharedResourceOptions } from '../interfaces'
 
-export interface QueryResourceOptions<ResourceData, TError = unknown> extends UseQueryOptions<ResourceData, TError> {
+export interface QueryResourceOptions<ResourceData, TError = unknown>
+  extends UseQueryOptions<ResourceData, TError>,
+    SharedResourceOptions {
   requestConfig?: RequestConfig
 }
 

--- a/src/data-provider/resource-provider/hooks/fetch-resource/useResource.ts
+++ b/src/data-provider/resource-provider/hooks/fetch-resource/useResource.ts
@@ -1,10 +1,11 @@
 import deepmerge from 'deepmerge'
 import { useMemo } from 'react'
-import { useQuery } from 'react-query'
+import { useQuery, useQueryClient } from 'react-query'
 import { ResourceOptionsOrKey } from '../../interfaces'
 import { useConfigResolver } from '../../../hooks/useConfigResolver'
 import { useResourceConfig } from '../useResourceConfig'
 import { QueryResourceOptions, ResourceQueryResult } from './interfaces'
+import { injectInCallback } from '../../utils/injectInCallback'
 
 export const useResource = <ResourceData>(
   userConfigOrKey: ResourceOptionsOrKey<ResourceData>,
@@ -16,10 +17,18 @@ export const useResource = <ResourceData>(
     key,
   } = useResourceConfig<ResourceData>(userConfig)
 
-  const { requestConfig = {}, ...queryOptions } = useMemo(
-    () => deepmerge(query, requestOptions),
-    [query, requestOptions]
-  )
+  const {
+    requestConfig = {},
+    overrideGlobalOnError,
+    ...queryOptions
+  } = useMemo(() => deepmerge(query, requestOptions), [query, requestOptions])
+
+  const queryClient = useQueryClient()
+  const globalOnError = queryClient.getDefaultOptions()?.queries?.onError
+
+  if (!!queryOptions.onError && globalOnError && !overrideGlobalOnError) {
+    queryOptions.onError = injectInCallback(queryOptions.onError, globalOnError)
+  }
 
   return useQuery([key, requestConfig.lookupField, requestConfig.params], () => fn(key, requestConfig), queryOptions)
 }

--- a/src/data-provider/resource-provider/hooks/interfaces.ts
+++ b/src/data-provider/resource-provider/hooks/interfaces.ts
@@ -1,0 +1,3 @@
+export interface SharedResourceOptions {
+  overrideGlobalOnError?: boolean
+}

--- a/src/data-provider/resource-provider/hooks/mutate-resource/interfaces.ts
+++ b/src/data-provider/resource-provider/hooks/mutate-resource/interfaces.ts
@@ -1,8 +1,11 @@
 import { MutationOptions as QueryMutationOptions, UseMutationResult } from 'react-query'
+
 import { RequestConfig } from '../../request-types'
+import { SharedResourceOptions } from '../interfaces'
 
 export interface MutationOptions<ResourceData, SourceData, TError = unknown, TContext = unknown>
-  extends QueryMutationOptions<ResourceData, TError, SourceData, TContext> {
+  extends QueryMutationOptions<ResourceData, TError, SourceData, TContext>,
+    SharedResourceOptions {
   requestConfig?: RequestConfig
 }
 

--- a/src/data-provider/resource-provider/hooks/mutate-resource/useMutateResource.ts
+++ b/src/data-provider/resource-provider/hooks/mutate-resource/useMutateResource.ts
@@ -1,10 +1,10 @@
 import deepmerge from 'deepmerge'
-import { useMemo } from 'react'
-import { useMutation } from 'react-query'
+import { useMutation, useQueryClient } from 'react-query'
 import { ResourceOptionsOrKey } from '../../interfaces'
 import { useConfigResolver } from '../../../hooks/useConfigResolver'
 import { useResourceConfig } from '../useResourceConfig'
 import { MutationOptions, MutationResult } from './interfaces'
+import { injectInCallback } from '../../utils/injectInCallback'
 
 export function useMutateResource<ResourceData, SourceData>(
   userConfigOrKey: ResourceOptionsOrKey<ResourceData, SourceData>,
@@ -17,9 +17,13 @@ export function useMutateResource<ResourceData, SourceData>(
     key,
   } = useResourceConfig<ResourceData, SourceData>(userConfig)
 
-  const { requestConfig, ...mutationOptions } = useMemo(
-    () => deepmerge(options, requestOptions),
-    [options, requestOptions]
-  )
+  const { requestConfig, overrideGlobalOnError, ...mutationOptions } = deepmerge(options, requestOptions)
+  const queryClient = useQueryClient()
+  const globalOnError = queryClient.getDefaultOptions()?.mutations?.onError
+
+  if (!!mutationOptions.onError && globalOnError && !overrideGlobalOnError) {
+    mutationOptions.onError = injectInCallback(mutationOptions.onError, globalOnError)
+  }
+
   return useMutation((data: SourceData) => fn(key, data, requestConfig), mutationOptions)
 }

--- a/src/data-provider/resource-provider/utils/injectInCallback.ts
+++ b/src/data-provider/resource-provider/utils/injectInCallback.ts
@@ -1,0 +1,12 @@
+type Callback<Args extends any[], ReturnType> = (...args: Args) => ReturnType
+
+export function injectInCallback<Args extends any[], ReturnType>(
+  callback: Callback<Args, ReturnType>,
+  injected: Callback<Args, ReturnType>
+): Callback<Args, ReturnType> {
+  return (...args) => {
+    const callbackResponse = callback(...args)
+    injected(...args)
+    return callbackResponse
+  }
+}


### PR DESCRIPTION
Глобальный обработчик onError вызывается после вызова локального обработчика. Это поведение можно отключить передав в опции хука `overrideGlobalOnError: true`. Возврат глобального обработчика будет игнорироваться, даже если он возвращает Promise.